### PR TITLE
Support of multiple MAC addresses for host declaration and a little fix to failover

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -242,7 +242,7 @@ dhcpd_subnet_default:
     routers: '{{ ansible_default_ipv4.gateway | default("") }}'
     comment: 'Generated automatically by Ansible'
   '6':
-    subnet: '{{ ansible_default_ipv6.address + "/" + ansible_default_ipv6.prefix }}'
+    subnet: '{{ ansible_default_ipv6.address|default("::1") + "/" + ansible_default_ipv6.prefix }}'
     comment: 'Generated automatically by Ansible'
 
 
@@ -270,7 +270,7 @@ dhcpd_failovers: []
 # .. envvar:: dhcpd_probe
 #
 # Enable or disable ``dhcp-probe`` script
-dhcpd_probe: True
+dhcpd_probe: False
 
 
 # .. envvar:: dhcpd_probe_mail_to

--- a/docs/defaults-configuration.rst
+++ b/docs/defaults-configuration.rst
@@ -289,7 +289,8 @@ hosts. Each dict can have following keys:
   Name of the host
 
 ``ethernet``
-  Ethernet address of this host
+  Ethernet address of this host, if host has multiple aggregated(bonded) links
+  you may specify their ethernet addresses as a list.
 
 ``address``
   IP address of this host
@@ -310,6 +311,11 @@ Examples::
     - hostname: 'examplehost'
       address: '10.0.10.1'
       ethernet: '00:00:00:00:00:00'
+    - hostname: 'bondedhost'
+      address: '10.0.10.2'
+      ethernet:
+        - '00:00:00:00:00:01'
+        - '00:00:00:00:00:02'
 
 .. _dhcpd_includes:
 

--- a/templates/etc/dhcp/dhcpd.conf.j2
+++ b/templates/etc/dhcp/dhcpd.conf.j2
@@ -1,4 +1,4 @@
-{% import 'macros.j2' as print with context %}
+{% import 'macros.j2' as tpl with context %}
 # {{ ansible_managed }}
 
 {% if dhcpd_authoritative is defined and dhcpd_authoritative %}
@@ -30,22 +30,22 @@ log-facility {{ dhcpd_log_facility }};
 {% include 'ipxe.j2' %}
 {% if dhcpd_keys is defined and dhcpd_keys %}
 {% for key in dhcpd_keys %}
-{{ print.key(key) }}
+{{ tpl.print_key(key) }}
 {% endfor %}
 {% endif %}
 {% if dhcpd_zones is defined and dhcpd_zones %}
 {% for zone in dhcpd_zones %}
-{{ print.zone(zone) }}
+{{ tpl.print_zone(zone) }}
 {% endfor %}
 {% endif %}
 {% if dhcpd_classes is defined and dhcpd_classes %}
 {% for class in dhcpd_classes %}
-{{ print.class(class) }}
+{{ tpl.print_class(class) }}
 {% endfor %}
 {% endif %}
 {% if dhcpd_failovers is defined and dhcpd_failovers %}
 {% for failover in dhcpd_failovers %}
-{{ print.failover(failover) }}
+{{ tpl.print_failover(failover) }}
 {% endfor %}
 {% endif %}
 {% if dhcpd_shared_networks is defined and dhcpd_shared_networks %}
@@ -63,7 +63,7 @@ shared-network "{{ network.name }}" {
 {% endif %}
 {% for subnet in network.subnets %}
 
-{{ print.subnet(subnet) | indent(8,true) }}
+{{ tpl.print_subnet(subnet) | indent(8,true) }}
 {% endfor %}
 }
 
@@ -72,16 +72,16 @@ shared-network "{{ network.name }}" {
 {% endif %}
 {% if dhcpd_groups is defined and dhcpd_groups %}
 {% for group in dhcpd_groups %}
-{{ print.group(group) }}
+{{ tpl.print_group(group) }}
 {% endfor %}
 {% endif %}
 {% if dhcpd_subnets is defined and dhcpd_subnets %}
 {% for subnet in dhcpd_subnets %}
-{{ print.subnet(subnet) }}
+{{ tpl.print_subnet(subnet) }}
 {% endfor %}
 {% endif %}
 {% if dhcpd_hosts is defined and dhcpd_hosts %}
-{{ print.hosts(dhcpd_hosts) }}
+{{ tpl.print_hosts(dhcpd_hosts) }}
 {% endif %}
 {% if dhcpd_includes is defined and dhcpd_includes %}
 {% for include in dhcpd_includes %}

--- a/templates/etc/dhcp/macros.j2
+++ b/templates/etc/dhcp/macros.j2
@@ -47,16 +47,16 @@ group {
 {% endif %}
 {% if group.groups is defined and group.groups %}
 {% for group in group.groups %}
-{{ print.group(group) | indent(8, true) }}
+{{ group(group) | indent(8, true) }}
 {% endfor %}
 {% endif %}
 {% if group.subnets is defined and group.subnets %}
 {% for subnet in group.subnets %}
-{{ print.subnet(subnet) | indent(8, true) }}
+{{ subnet(subnet) | indent(8, true) }}
 {% endfor %}
 {% endif %}
 {% if group.hosts is defined and group.hosts %}
-{{ print.hosts(group.hosts) | indent(8, true) }}
+{{ hosts(group.hosts) | indent(8, true) }}
 {% endif %}
 }
 {% endmacro %}
@@ -113,7 +113,7 @@ subnet {{ subnet.subnet | ipaddr('cidr') | ipaddr('address') }} netmask 255.255.
 {% endfor %}
 {% endif %}
 {% if subnet.hosts is defined and subnet.hosts %}
-{{ print.hosts(subnet.hosts) | indent(8, true) }}
+{{ hosts(subnet.hosts) | indent(8, true) }}
 {% endif %}
 }
 {% endmacro %}
@@ -129,6 +129,23 @@ include "{{ hosts }}";
 {% if host.comment is defined and host.comment %}
 # {{ host.comment }}
 {% endif %}
+{# Hack to support host with multiple MACs #}
+{% if host.ethernet is defined and host.ethernet is sequence and not host.ethernet is string %}
+{% for hwaddr in host.ethernet %}
+host {{ host.hostname }}-hw{{ loop.index }} {
+{% if host.options is defined and host.options %}
+{{ host.options | indent(8,true) }}
+{% endif %}
+        hardware ethernet {{ hwaddr }};
+{% if not host.options is defined or (host.options and not 'host-name' in host.options) %}
+        option host-name = {{ host.hostname }};
+{% endif %}
+{% if host.address is defined and host.address %}
+        fixed-address {{ host.address }};
+{% endif %}
+}
+{% endfor %}
+{% else %}
 host {{ host.hostname }} {
 {% if host.options is defined and host.options %}
 {{ host.options | indent(8,true) }}
@@ -144,6 +161,7 @@ host {{ host.hostname }} {
 {% endif %}
 {% endif %}
 }
+{% endif %}
 {% endfor %}
 {% endif %}
 {% endmacro %}
@@ -156,7 +174,7 @@ host {{ host.hostname }} {
 # {{ failover.comment }}
 {% endif %}
 failover peer "{{ failover.failover }}" {
-{% if failover.primary is defined and failover.primary ==  inventory_hostname %}
+{% if failover.primary is defined and failover.primary in ansible_all_ipv4_addresses %}
         primary;
         mclt {{ failover.mclt|default(3600) }};
 {% if failover.primary_fo_addr is defined and failover.primary_fo_addr %}

--- a/templates/etc/dhcp/macros.j2
+++ b/templates/etc/dhcp/macros.j2
@@ -2,9 +2,10 @@
 #   List of macros for ISC DHCP configuration, IPv4
 #   ===============================================
 #
-#   ---- Macro: print.class() ----
+#   ---- Macro: print_class() ----
 #}
-{% macro class(class) %}
+{% set print = self %}
+{% macro print_class(class) %}
 {% if class.comment is defined and class.comment %}
 # {{ class.comment }}
 {% endif %}
@@ -32,9 +33,9 @@ subclass "{{ class.class }}" {{ key }};
 {% endmacro %}
 {#
 #
-#   ---- Macro: print.group() ----
+#   ---- Macro: print_group() ----
 #}
-{% macro group(group) %}
+{% macro print_group(group) %}
 {% if group.comment is defined and group.comment %}
 # {{ group.comment }}
 {% endif %}
@@ -47,24 +48,24 @@ group {
 {% endif %}
 {% if group.groups is defined and group.groups %}
 {% for group in group.groups %}
-{{ group(group) | indent(8, true) }}
+{{ print_group(group) | indent(8, true) }}
 {% endfor %}
 {% endif %}
 {% if group.subnets is defined and group.subnets %}
 {% for subnet in group.subnets %}
-{{ subnet(subnet) | indent(8, true) }}
+{{ print_subnet(subnet) | indent(8, true) }}
 {% endfor %}
 {% endif %}
 {% if group.hosts is defined and group.hosts %}
-{{ hosts(group.hosts) | indent(8, true) }}
+{{ print_hosts(group.hosts) | indent(8, true) }}
 {% endif %}
 }
 {% endmacro %}
 {#
 #
-#   ---- Macro: print.subnet() ----
+#   ---- Macro: print_subnet() ----
 #}
-{% macro subnet(subnet) %}
+{% macro print_subnet(subnet) %}
 {% if subnet.comment is defined and subnet.comment %}
 # {{ subnet.comment }}
 {% endif %}
@@ -113,15 +114,15 @@ subnet {{ subnet.subnet | ipaddr('cidr') | ipaddr('address') }} netmask 255.255.
 {% endfor %}
 {% endif %}
 {% if subnet.hosts is defined and subnet.hosts %}
-{{ hosts(subnet.hosts) | indent(8, true) }}
+{{ print_hosts(subnet.hosts) | indent(8, true) }}
 {% endif %}
 }
 {% endmacro %}
 {#
 #
-#   ---- Macro: print.hosts() ----
+#   ---- Macro: print_hosts() ----
 #}
-{% macro hosts(hosts) %}
+{% macro print_hosts(hosts) %}
 {% if hosts is string %}
 include "{{ hosts }}";
 {% else %}
@@ -167,9 +168,9 @@ host {{ host.hostname }} {
 {% endmacro %}
 {#
 #
-#   ---- Macro: print.failover() ----
+#   ---- Macro: print_failover() ----
 #}
-{% macro failover(failover) %}
+{% macro print_failover(failover) %}
 {% if failover.comment is defined and failover.comment %}
 # {{ failover.comment }}
 {% endif %}
@@ -229,9 +230,9 @@ failover peer "{{ failover.failover }}" {
 {% endmacro %}
 {#
 #
-#   ---- Macro: print.key() ----
+#   ---- Macro: print_key() ----
 #}
-{% macro key(key) %}
+{% macro print_key(key) %}
 {% if key.comment is defined and key.comment %}
 # {{ key.comment }}
 {% endif %}
@@ -242,9 +243,9 @@ key {{ key.key }} {
 {% endmacro %}
 {#
 #
-#   ---- Macro: print.zone() ----
+#   ---- Macro: print_zone() ----
 #}
-{% macro zone(zone) %}
+{% macro print_zone(zone) %}
 {% if zone.comment is defined and zone.comment %}
 # {{ zone.comment }}
 {% endif %}


### PR DESCRIPTION
I'm back again with a new PR.

I've run into some problems with static DHCP reservations on bonded interfaces:

* The resulting MAC address assigned to the bond can be inherited from any slave interface, whichever is first added to the bond.
* When using iPXE to boot from LACP enabled interfaces it will choose any of the slave interfaces whichever discovered first.

So I wrote a small patch to support assignment of multiple MACs to a single host. It creates a separate host statements for each MAC(because dhcpd wants them to be unique).
If no 'option host-name' is specified in 'host.options' - it is added. This is made for compatibility with 'use-host-decl-names on' dhcpd option.

Also there is a small patch for failover configuration which allows usage of hostnames in inventory file.

And some fixes for group expanding macros.