### PR TITLE
fix [DEPRECATION WARNING] ansible ver 2.0.1.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
     state: 'present'
     install_recommends: False
   with_flattened:
-    - dhcpd_base_packages_map[dhcpd_mode]
+    - '{{ dhcpd_base_packages_map[dhcpd_mode] }}'
     - [ '{{ "dhcp-probe" if (dhcpd_probe|d() and dhcpd_probe) else [] }}' ]
 
 - name: Reconfigure ISC DHCP relay
@@ -58,7 +58,7 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  with_items: dhcpd_includes
+  with_items: '{{ dhcpd_includes }}'
   notify: [ 'Restart isc-dhcp-server' ]
   when: ((item is defined and item) and dhcpd_mode == 'server' and
          (dhcpd_register_config is defined and dhcpd_register_config.changed))


### PR DESCRIPTION
```
TASK [debops.dhcpd : Install DHCP packages] ************************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that 
the environment value uses the full variable syntax 
('{{dhcpd_base_packages_map[dhcpd_mode]}}'). This feature will be removed in a future 
release. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
ok: [dhcp.samara.mpautina.ru] => (item=[u'isc-dhcp-server', u'bind9utils'])
```

```
TASK [debops.dhcpd : Make sure that included files exist] **********************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that 
the environment value uses the full variable syntax ('{{dhcpd_includes}}'). This feature 
will be removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```