### PR TITLE
always_run is deprecated. Use check_mode = no instead..

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+ *Unreleased*
+
+- Fix Ansible 2.2 deprecation warnings. [brzhk]
+
 v0.1.2
 ------
 
@@ -43,4 +47,3 @@ v0.1.0
 *Released: 2015-03-30*
 
 - First release [drybjed]
-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
  *Unreleased*
 
-- Fix Ansible 2.2 deprecation warnings. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
 
 v0.1.2
 ------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,8 @@ Changelog
 
  *Unreleased*
 
-- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher. Support for older Ansible versions is dropped. [brzhk]
+- Fix Ansible 2.2 deprecation warnings which requires Ansible 2.2 or higher.
+  Support for older Ansible versions is dropped. [brzhk]
 
 v0.1.2
 ------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,7 @@ galaxy_info:
   description: 'Install and configure ISC DHCP Server'
   company: 'DebOps'
   license: 'GNU General Public License v3'
-  min_ansible_version: '1.7.0'
+  min_ansible_version: '2.2.0'
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
   register: dhcpd_register_nameservers
   changed_when: False
   when: dhcpd_mode == 'server'
-  always_run: yes
+  check_mode: no
 
 - name: Convert list of nameservers to Ansible list
   set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
   register: dhcpd_register_nameservers
   changed_when: False
   when: dhcpd_mode == 'server'
-  check_mode: no
+  check_mode: False
 
 - name: Convert list of nameservers to Ansible list
   set_fact:


### PR DESCRIPTION
[DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.